### PR TITLE
Update macroscopic_magnetism.cpp

### DIFF
--- a/Physics/magnetism/macroscopic_magnetism.cpp
+++ b/Physics/magnetism/macroscopic_magnetism.cpp
@@ -1,44 +1,141 @@
-class macroscopic_magnetism{
-    public:
-        uint8192_t magnetic_field_of_cube(uint8192_t length_of_side, uint8192_t electric_field){
-            uint8192_t M = (length_of_side_of_cube * length_of_side_of_cube) * electric_field;
-            return M;
-        }
+#include <cmath>
+#include <stdexcept>
+#include <cstdint>
+#include <algorithm>
 
-        uint8192_t magnetic_field_of_cuboid (uint8192_t length_of_object, uint8192_t electric_field){
-            uint8192_t M = (electric_field * length_of_object * length_of_object)/2;
-            return M;
-        }
-        
-        uint8192_t magnetic_field_of_sphere (uint8192_t radius_of_object, uint8192_t volumetric_height , uint8192_t electric_field){
-            uint8192_t M = (pi* radius_of_object * radius_of_object * volumetric_height * electric_field)/2;
-            return M;
-        }
+using uint8192_t = __int128; // Placeholder for a hypothetical 8192-bit unsigned integer type
 
-        uint8192_t magnetic_field_of_pyramid (uint8192_t base_of_triangle, uint8192_t height_of_triangle, uint8192_t volumetric_height, uint8192_t electric_field){
-            uint8192_t M = (((base_of_triangle * height_of_triangle)/2) * volumetric_height) * electric_field;
-            return M;
-        }
+class macroscopic_magnetism {
+public:
+    // **Constants**
+    static constexpr double PI = 3.14159265358979323846;
+    static constexpr uint8192_t MU_0 = 1; // Placeholder for vacuum permeability (scaled for uint8192_t)
 
-        uint8192_t mmf_of_cube (uint8192_t length_of_side, uint8192_t current, uint8192_t resistance_of_material, uint8192_t volumetric_height){
-            uint8192_t mmf = ((length_of_side * length_of_side * length_of_side) * (volumetric_height * volumetric_height * volumetric_height) * (current * current) * (resistance_of_material * resistance_of_material))/24;
-            return mmf;
-        }
+    // **Magnetic Field Calculations**
 
-        uint8192_t mmf_of_cuboid (uint8192_t current, uint8192_t resistance_of_material, uint8192_t length_of_material, uint8192_t breadth_of_material, uint8192_t volumetric_height, uint8192_t electric_field){
-            uint8192_t mmf = ((((current * current) * resistance_of_material) * electric_field) * (length_of_material * length_of_material) * (breadth_of_material * breadth_of_material) * (volumetric_height * volumetric_height))/8;
-            return mmf;
-        }
+    /** Calculates magnetic field at the center of a cube due to uniform current density induced by an electric field */
+    uint8192_t magnetic_field_of_cube(uint8192_t length_of_side, uint8192_t electric_field, uint8192_t conductivity) {
+        validate_positive("magnetic_field_of_cube", {length_of_side, electric_field, conductivity});
+        uint8192_t current_density = conductivity * electric_field;
+        // Simplified B = μ₀ * J * L / 2 (approximation at center)
+        return (MU_0 * current_density * length_of_side) / 2;
+    }
 
-        uint8192_t mmf_of_pyramid (uint8192_t current, uint8192_t base, uint8192_t height, uint8192_t volumetric_height){
-            uint8192_t mmf = ((current * current) * (base * base) * (height * height) * (volumetric_height * volumetric_height))/16;
-            return mmf;
-        }
+    /** Calculates magnetic field at the center of a cuboid */
+    uint8192_t magnetic_field_of_cuboid(uint8192_t length, uint8192_t width, uint8192_t height, uint8192_t electric_field, uint8192_t conductivity) {
+        validate_positive("magnetic_field_of_cuboid", {length, width, height, electric_field, conductivity});
+        uint8192_t current_density = conductivity * electric_field;
+        uint8192_t min_dim = std::min({length, width, height});
+        return (MU_0 * current_density * min_dim) / 2;
+    }
 
-        uint8192_t mmf_of_sphere (double8192_t radius, double8192_t height){
-            uint8192_t mmf = (pi * (radius * radius * radius) * (height * height * height))/6;
-            return mmf;
-        }
+    /** Calculates magnetic field at the center of a sphere (zero due to symmetry with uniform current density) */
+    uint8192_t magnetic_field_of_sphere(uint8192_t radius, uint8192_t electric_field, uint8192_t conductivity) {
+        validate_positive("magnetic_field_of_sphere", {radius, electric_field, conductivity});
+        // Uniform current density in a sphere produces zero field at the center due to symmetry
+        return 0;
+    }
 
-        
+    /** Calculates magnetic field at the apex of a pyramid */
+    uint8192_t magnetic_field_of_pyramid(uint8192_t base, uint8192_t height, uint8192_t electric_field, uint8192_t conductivity) {
+        validate_positive("magnetic_field_of_pyramid", {base, height, electric_field, conductivity});
+        uint8192_t current_density = conductivity * electric_field;
+        // Simplified B = μ₀ * J * H / 3 (approximation at apex)
+        return (MU_0 * current_density * height) / 3;
+    }
+
+    /** New: Magnetic field of a cylinder at its axis */
+    uint8192_t magnetic_field_of_cylinder(uint8192_t radius, uint8192_t height, uint8192_t electric_field, uint8192_t conductivity) {
+        validate_positive("magnetic_field_of_cylinder", {radius, height, electric_field, conductivity});
+        uint8192_t current_density = conductivity * electric_field;
+        return (MU_0 * current_density * radius) / 2; // Field along axis
+    }
+
+    // **Magnetomotive Force (MMF) Calculations**
+
+    /** MMF for a cube with a current loop around it */
+    uint8192_t mmf_of_cube(uint8192_t length_of_side, uint8192_t current) {
+        validate_positive("mmf_of_cube", {length_of_side, current});
+        return current; // MMF = I for a single loop
+    }
+
+    /** MMF for a cuboid with a current loop */
+    uint8192_t mmf_of_cuboid(uint8192_t length, uint8192_t width, uint8192_t height, uint8192_t current) {
+        validate_positive("mmf_of_cuboid", {length, width, height, current});
+        return current;
+    }
+
+    /** MMF for a pyramid with a current loop around its base */
+    uint8192_t mmf_of_pyramid(uint8192_t base, uint8192_t height, uint8192_t current) {
+        validate_positive("mmf_of_pyramid", {base, height, current});
+        return current;
+    }
+
+    /** MMF for a sphere with a current loop around its equator */
+    uint8192_t mmf_of_sphere(uint8192_t radius, uint8192_t current) {
+        validate_positive("mmf_of_sphere", {radius, current});
+        return current;
+    }
+
+    /** New: MMF for a cylinder with a current loop around its circumference */
+    uint8192_t mmf_of_cylinder(uint8192_t radius, uint8192_t height, uint8192_t current) {
+        validate_positive("mmf_of_cylinder", {radius, height, current});
+        return current;
+    }
+
+    // **New Features**
+
+    /** Magnetic flux through a surface */
+    uint8192_t magnetic_flux(uint8192_t magnetic_field, uint8192_t area) {
+        validate_positive("magnetic_flux", {magnetic_field, area});
+        return magnetic_field * area;
+    }
+
+    /** Energy stored in a magnetic field within a volume */
+    uint8192_t magnetic_energy(uint8192_t magnetic_field, uint8192_t volume, uint8192_t permeability) {
+        validate_positive("magnetic_energy", {magnetic_field, volume, permeability});
+        // Energy = (B² * V) / (2 * μ)
+        return (magnetic_field * magnetic_field * volume) / (2 * permeability);
+    }
+
+    /** Magnetic dipole moment for a current loop */
+    uint8192_t magnetic_dipole_moment(uint8192_t current, uint8192_t area) {
+        validate_positive("magnetic_dipole_moment", {current, area});
+        return current * area;
+    }
+
+    /** Magnetic field due to a dipole at a distance along its axis */
+    uint8192_t magnetic_field_due_to_dipole(uint8192_t dipole_moment, uint8192_t distance) {
+        validate_positive("magnetic_field_due_to_dipole", {dipole_moment, distance});
+        // B = (μ₀ * 2 * m) / (4π * r³)
+        return (MU_0 * 2 * dipole_moment) / (4 * PI * distance * distance * distance);
+    }
+
+    /** Reluctance of a magnetic circuit */
+    uint8192_t reluctance(uint8192_t length, uint8192_t area, uint8192_t permeability) {
+        validate_positive("reluctance", {length, area, permeability});
+        return length / (permeability * area);
+    }
+
+    /** Magnetic flux density (B) from H and magnetization M */
+    uint8192_t magnetic_flux_density(uint8192_t magnetic_field_intensity, uint8192_t magnetization, uint8192_t permeability) {
+        validate_positive("magnetic_flux_density", {magnetic_field_intensity, magnetization, permeability});
+        return MU_0 * (magnetic_field_intensity + magnetization);
+    }
+
+    /** New: Magnetic field of a toroidal coil */
+    uint8192_t magnetic_field_of_toroid(uint8192_t radius, uint8192_t turns, uint8192_t current) {
+        validate_positive("magnetic_field_of_toroid", {radius, turns, current});
+        return (MU_0 * turns * current) / (2 * PI * radius);
+    }
+
+private:
+    /** Helper function to validate that all parameters are positive */
+    void validate_positive(const std::string& function_name, const std::initializer_list<uint8192_t>& params) {
+        for (auto param : params) {
+            if (param <= 0) {
+                throw std::invalid_argument("Invalid parameter in " + function_name + ": all parameters must be positive");
+            }
+        }
+    }
 };


### PR DESCRIPTION
Physical Consistency
Magnetic Fields: The original formulas were arbitrary (e.g., M = length² * electric_field for a cube). I've replaced them with simplified models based on physical principles: Assumes an electric field induces a current density J = σ * E (where σ is conductivity).

Magnetic field B is approximated using B ≈ μ₀ * J * characteristic_length, adjusted for each shape.

MMF: Redefined as MMF = I for a single current loop, aligning with the standard definition of magnetomotive force, rather than the overly complex original formulas.

2. Expanded Functionality New Shapes: Added magnetic_field_of_cylinder and mmf_of_cylinder for cylindrical geometry.

Advanced Calculations:
magnetic_flux: Computes Φ = B * A.

magnetic_energy: Calculates E = (B² * V) / (2 * μ).

magnetic_dipole_moment: Computes m = I * A.

magnetic_field_due_to_dipole: Calculates field along the dipole axis.

reluctance: Computes R = l / (μ * A) for magnetic circuits.

magnetic_flux_density: Relates B = μ₀ * (H + M).

magnetic_field_of_toroid: Models a toroidal coil's field.

3. Error Handling Added a validate_positive helper function to ensure all inputs are positive, throwing std::invalid_argument for invalid cases.

4. Parameter Standardization Consistent naming: length, width, height, radius, etc., replacing ambiguous terms like length_of_object or volumetric_height.

Removed unnecessary parameters (e.g., resistance_of_material in MMF calculations where it didn’t apply).

5. Code Structure Used comments and documentation for clarity.

Defined constants like PI and MU_0 as static constexpr for reuse.

Employed std::min and std::algorithm for robust calculations.

Notes
Type Limitation: uint8192_t is assumed to be a large unsigned integer (here simulated with __int128). In practice, double would be better for physical quantities, but I retained uint8192_t to match the original code.

Simplifications: Calculations are simplified for educational purposes rather than exact physical models, which would require vector fields and integration (e.g., Biot-Savart law).

Scalability: The class now supports a wide range of magnetism-related computations, making it far more versatile than the original.