### PR TITLE
Update distributions.cpp

### DIFF
--- a/Mathematics/distributions.cpp
+++ b/Mathematics/distributions.cpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <cstdint>
 #include <stdexcept>
+#include <random>
 
 class binomial_distribution {
 public:
@@ -27,6 +28,70 @@ public:
             sum += pmf(i);
         }
         return sum;
+    }
+
+    // Approximate CDF using normal distribution with continuity correction
+    double approx_cdf(uint64_t k) const {
+        double mu = static_cast<double>(n_) * p_;
+        double sigma = std::sqrt(static_cast<double>(n_) * p_ * (1.0 - p_));
+        if (sigma == 0.0) {
+            if (n_ == 0 || p_ == 0.0) {
+                return 1.0; // Degenerate at 0
+            } else { // p_ == 1.0 and n_ > 0
+                return (k >= n_) ? 1.0 : 0.0; // Degenerate at n_
+            }
+        }
+        double z = (static_cast<double>(k) + 0.5 - mu) / sigma;
+        return normal_cdf(z);
+    }
+
+    // Quantile function: smallest k such that P(X <= k) >= prob
+    uint64_t quantile(double prob) const {
+        if (prob < 0.0 || prob > 1.0) {
+            throw std::invalid_argument("Probability must be between 0 and 1.");
+        }
+        if (prob == 0.0) return 0;
+        if (prob == 1.0) return n_;
+        uint64_t low = 0;
+        uint64_t high = n_;
+        while (low < high) {
+            uint64_t mid = low + (high - low) / 2;
+            double cdf_mid = cdf(mid);
+            if (cdf_mid < prob) {
+                low = mid + 1;
+            } else {
+                high = mid;
+            }
+        }
+        return low;
+    }
+
+    // Generate a random sample from the binomial distribution
+    uint64_t sample(std::mt19937& gen) const {
+        uint64_t sum = 0;
+        std::uniform_real_distribution<double> dist(0.0, 1.0);
+        for (uint64_t i = 0; i < n_; ++i) {
+            if (dist(gen) < p_) sum++;
+        }
+        return sum;
+    }
+
+    // Compute the mode(s) of the distribution
+    std::vector<uint64_t> modes() const {
+        double m = (n_ + 1) * p_;
+        if (std::floor(m) == m) { // m is an integer
+            uint64_t k = static_cast<uint64_t>(m);
+            if (k == 0) {
+                return {0};
+            } else if (k == n_ + 1) {
+                return {n_};
+            } else {
+                return {k - 1, k};
+            }
+        } else {
+            uint64_t k = static_cast<uint64_t>(std::floor(m));
+            return {k};
+        }
     }
 
     // Mean: n * p
@@ -63,6 +128,34 @@ public:
         return result;
     }
 
+    // Generate a vector of CDF values for k = 0 to n
+    std::vector<double> cdf_vector() const {
+        std::vector<double> result(n_ + 1);
+        double sum = 0.0;
+        for (uint64_t k = 0; k <= n_; ++k) {
+            sum += pmf(k);
+            result[k] = sum;
+        }
+        return result;
+    }
+
+    // Moment-Generating Function: (1 - p + p * e^t)^n
+    double mgf(double t) const {
+        return std::pow(1.0 - p_ + p_ * std::exp(t), static_cast<double>(n_));
+    }
+
+    // Entropy: -sum(p(k) * log(p(k)))
+    double entropy() const {
+        double sum = 0.0;
+        for (uint64_t k = 0; k <= n_; ++k) {
+            double p_k = pmf(k);
+            if (p_k > 0.0) {
+                sum += p_k * std::log(p_k);
+            }
+        }
+        return -sum;
+    }
+
 private:
     uint64_t n_; // Number of trials
     double p_;   // Probability of success
@@ -76,5 +169,10 @@ private:
             result *= static_cast<double>(n - k + i) / static_cast<double>(i);
         }
         return result;
+    }
+
+    // Standard normal CDF using erf
+    double normal_cdf(double x) const {
+        return 0.5 * (1.0 + std::erf(x / std::sqrt(2.0)));
     }
 };


### PR DESCRIPTION
1. Random Sample Generation (sample) Purpose: Allows users to generate random samples from the binomial distribution, useful for simulations and statistical experiments.

Implementation: 
Uses the <random> library with a std::mt19937 random number generator passed by reference.

Simulates n_ independent Bernoulli trials, each with success probability p_, by generating uniform random numbers between 0 and 1 and comparing them to p_.

Returns the sum of successes as a uint64_t.

2. Quantile Function (quantile) Purpose: Computes the inverse CDF, returning the smallest k such that P(X <= k) >= prob. Useful for finding critical values in hypothesis testing or confidence intervals.

Implementation: 
Uses binary search to efficiently find the quantile, leveraging the monotonicity of the CDF.

Handles edge cases: returns 0 for prob = 0.0, n_ for prob = 1.0, and throws an exception for invalid probabilities.

3. Mode Computation (modes) Purpose: Returns the mode(s) of the distribution, i.e., the value(s) of k with the highest probability.

Implementation: 
For a binomial distribution, the mode is typically floor((n + 1) * p). If (n + 1) * p is an integer m, there are two modes: m - 1 and m (within the support {0, ..., n}).

Handles special cases: returns {0} if p = 0.0, {n_} if p = 1.0.

Returns a std::vector<uint64_t> with one or two elements.

Purpose: Provides a faster CDF computation for large n using the normal approximation with continuity correction.

Implementation: 
Approximates the binomial distribution with a normal distribution N(np, np(1-p)).

Applies continuity correction by using k + 0.5 in the z-score calculation: z = (k + 0.5 - mu) / sigma.

Uses a helper function normal_cdf to compute the standard normal CDF via std::erf.

Handles degenerate cases (sigma = 0) when n_ = 0, p_ = 0.0, or p_ = 1.0.


5. CDF Vector (cdf_vector) Purpose: Complements pmf_vector by returning a vector of cumulative probabilities from k = 0 to n_.

Implementation: 
Iterates over k from 0 to n_, accumulating PMF values into a cumulative sum.

Returns a std::vector<double> of size n_ + 1.

6. Moment-Generating Function (mgf) Purpose: Computes the moment-generating function, useful in probability theory for deriving moments or working with sums of random variables.

Implementation: 
For a binomial distribution, M(t) = (1 - p + p * e^t)^n.

Uses std::exp and std::pow for the calculation.


Purpose: Calculates the Shannon entropy, a measure of the distribution’s uncertainty or information content.

Implementation: 
Computes -sum(p(k) * log(p(k))) over all k from 0 to n_.

Skips terms where p(k) = 0 to avoid undefined logarithms.